### PR TITLE
[再作成]　動作確認とコスト関数、通知されるタイミングの変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,15 @@ STACKNAME := "amazonBraketMonitoringTool"
 REGION := "us-west-1"
 SLACKPOSTURL := "slack post url starting from https:"
 notificationEmail := "notification email"
+MAXNUM := 100
+MAXCOST := 1
 
 build: FORCE
 	sam build
 
 deploy: build FORCE
 	sam deploy --resolve-s3 --stack-name $(STACKNAME) --region $(REGION) \
-		--parameter-overrides SLACKPOSTURL=$(SLACKPOSTURL) NOTIFICATIONEMAIL=$(notificationEmail)
+		--parameter-overrides SLACKPOSTURL=$(SLACKPOSTURL) NOTIFICATIONEMAIL=$(notificationEmail) MAXNUM=$(MAXNUM) MAXCOST=$(MAXCOST)
 
 clean: FORCE
 	sam delete --stack-name $(STACKNAME) --region $(REGION)

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,15 @@ STACKNAME := "amazonBraketMonitoringTool"
 REGION := "us-west-1"
 SLACKPOSTURL := "slack post url starting from https:"
 notificationEmail := "notification email"
-MAXNUM := 100
-MAXCOST := 1
+MAXSHOTNUM := 100
+MAXSHOTCOST := 1
 
 build: FORCE
 	sam build
 
 deploy: build FORCE
 	sam deploy --resolve-s3 --stack-name $(STACKNAME) --region $(REGION) \
-		--parameter-overrides SLACKPOSTURL=$(SLACKPOSTURL) NOTIFICATIONEMAIL=$(notificationEmail) MAXNUM=$(MAXNUM) MAXCOST=$(MAXCOST)
+		--parameter-overrides SLACKPOSTURL=$(SLACKPOSTURL) NOTIFICATIONEMAIL=$(notificationEmail) MAXSHOTNUM=$(MAXSHOTNUM) MAXSHOTCOST=$(MAXSHOTCOST)
 
 clean: FORCE
 	sam delete --stack-name $(STACKNAME) --region $(REGION)

--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -27,8 +27,8 @@ def lambda_handler(event: dict, context: dict) -> dict:
     # 定数設定
     SLACK_POST_URL = os.environ["SLACK_POST_URL"]
     TOPIC_ARN = os.environ["TOPIC_ARN"]
-    MAX_SHOT_NUM = int(os.environ["MAX_NUM"])
-    MAX_SHOT_COST = int(os.environ["MAX_COST"])  # dollar
+    MAX_SHOT_NUM = int(os.environ["MAX_SHOT_NUM"])
+    MAX_SHOT_COST = int(os.environ["MAX_SHOT_COST"])  # dollar
 
     logger.info(event)
 

--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -27,8 +27,8 @@ def lambda_handler(event: dict, context: dict) -> dict:
     # 定数設定
     SLACK_POST_URL = os.environ["SLACK_POST_URL"]
     TOPIC_ARN = os.environ["TOPIC_ARN"]
-    MAX_SHOT_NUM = 50
-    MAX_SHOT_COST = 5  # dollar
+    MAX_SHOT_NUM = int(os.environ["MAX_NUM"])
+    MAX_SHOT_COST = int(os.environ["MAX_COST"])  # dollar
 
     logger.info(event)
 
@@ -108,16 +108,16 @@ def lambda_handler(event: dict, context: dict) -> dict:
         task_info_each_status,
     )
 
-    # deleted_result: dict = delete_task_over_max_cost(
-    #    MAX_SHOT_COST,
-    #    clients,
-    #    device_region_index_dict,
-    #    device_provider,
-    #    device_name,
-    #    shots_count_each_status,
-    #    task_info_each_status,
-    #    task_count_each_status,
-    # )
+    deleted_result: dict = delete_task_over_max_cost(
+        MAX_SHOT_COST,
+        clients,
+        device_region_index_dict,
+        device_provider,
+        device_name,
+        shots_count_each_status,
+        task_info_each_status,
+        task_count_each_status,
+    )
 
     send_email(lambda_output, TOPIC_ARN)
     post_slack(lambda_output, deleted_result, SLACK_POST_URL, event, context)

--- a/template.yaml
+++ b/template.yaml
@@ -14,6 +14,15 @@ Parameters:
     AllowedPattern: "[\\w\\-._]+@[\\w\\-._]+\\.[A-Za-z]+"
     ConstraintDescription: "NOTIFICATIONEMAIL must be email."
 
+  MAXNUM:
+    Type: Number
+    Description: Enter Max number of shots.
+
+  MAXCOST:
+    Type: Number
+    Description: Enter Max cost. 
+
+
 Resources:
   srcLambdaFunction:
     Type: "AWS::Serverless::Function"
@@ -28,6 +37,8 @@ Resources:
         Variables:
           SLACK_POST_URL: !Ref SLACKPOSTURL
           TOPIC_ARN: !Ref NotifyMailSNSTopic
+          MAX_NUM: !Ref MAXNUM
+          MAX_COST: !Ref MAXCOST
       Policies:
         - AmazonBraketFullAccess
         - SNSPublishMessagePolicy:
@@ -40,7 +51,7 @@ Resources:
               {
                 "detail-type": ["Braket Task State Change"],
                 "source": ["aws.braket"],
-                "detail": { "status": ["CREATED"] },
+                "detail": { "status": ["CREATED","CANCELLED"] },
               }
 
   NotifyMailSNSTopic:

--- a/template.yaml
+++ b/template.yaml
@@ -14,11 +14,11 @@ Parameters:
     AllowedPattern: "[\\w\\-._]+@[\\w\\-._]+\\.[A-Za-z]+"
     ConstraintDescription: "NOTIFICATIONEMAIL must be email."
 
-  MAXNUM:
+  MAXSHOTNUM:
     Type: Number
     Description: Enter Max number of shots.
 
-  MAXCOST:
+  MAXSHOTCOST:
     Type: Number
     Description: Enter Max cost. 
 
@@ -37,8 +37,8 @@ Resources:
         Variables:
           SLACK_POST_URL: !Ref SLACKPOSTURL
           TOPIC_ARN: !Ref NotifyMailSNSTopic
-          MAX_NUM: !Ref MAXNUM
-          MAX_COST: !Ref MAXCOST
+          MAX_SHOT_NUM: !Ref MAXSHOTNUM
+          MAX_SHOT_COST: !Ref MAXSHOTCOST
       Policies:
         - AmazonBraketFullAccess
         - SNSPublishMessagePolicy:


### PR DESCRIPTION
変更点１：delete_task_over_max_costがコメントアウトになってたのでコメントを削除し、コストとshots数の両方から削除を行うように

変更点２：削除の閾値がコストとshots数ともにコードに直書きだったので、Makefileから調整できるように

変更点３：タスク作成時のみではなくタスク作成時とタスクキャンセル時に通知が来るようにした。

作成し直しました。